### PR TITLE
fix: drop io/ioutil

### DIFF
--- a/jwt/config.go
+++ b/jwt/config.go
@@ -17,7 +17,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"time"
 
@@ -86,7 +85,7 @@ func (js jwtSource) Token() (*oauth2.Token, error) {
 		return nil, fmt.Errorf("oauth2: cannot fetch token: %v", err)
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
 		return nil, fmt.Errorf("oauth2: cannot fetch token: %v", err)
 	}

--- a/key/key.go
+++ b/key/key.go
@@ -3,13 +3,13 @@ package key
 import (
 	"crypto/rsa"
 	"fmt"
-	"io/ioutil"
+	"os"
 )
 
 // FromFile loads a private key from the provided path and parses it.
 // The private key is returned if parsing succeeds.
 func FromFile(path string) (*rsa.PrivateKey, error) {
-	key, err := ioutil.ReadFile(path)
+	key, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read private key: %s", err.Error())
 	}


### PR DESCRIPTION
Drop deprecated `io/ioutil` package.

References:
- https://pkg.go.dev/io/ioutil