### PR TITLE
Add nolint for deferred jwt token

### DIFF
--- a/jwt/config.go
+++ b/jwt/config.go
@@ -84,7 +84,7 @@ func (js jwtSource) Token() (*oauth2.Token, error) {
 	if err != nil {
 		return nil, fmt.Errorf("oauth2: cannot fetch token: %v", err)
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() // nolint:errcheck
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
 		return nil, fmt.Errorf("oauth2: cannot fetch token: %v", err)


### PR DESCRIPTION
add nolint for the deferred jwt token as we don't need an error check.